### PR TITLE
[codex] Fix Firebase deploy workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,11 +9,12 @@ jobs:
   build_and_preview:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: '12'
-      - run: npm install
+          node-version: '24'
+          cache: 'npm'
+      - run: npm ci
       - run: npm run build
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:

--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,6 @@
 {
   "hosting": {
-    "public": "build",
+    "public": "dist",
     "ignore": [
       "firebase.json",
       "**/.*",


### PR DESCRIPTION
## Summary

Fixes the Firebase Hosting deploy workflow after the Vite migration.

- Updates GitHub Actions from Node 12 to Node 24 via `actions/setup-node@v4`
- Uses `npm ci` so CI installs from the committed lockfile
- Updates Firebase Hosting's public directory from CRA's `build` output to Vite's `dist` output

## Validation

- `npm ci --registry=https://registry.npmjs.org/`
- `npm run build`
- `npm audit --json --registry=https://registry.npmjs.org/`

## Notes

The failing deployment run did not reach Firebase auth or hosting deployment. It failed during `npm run build` because the workflow still used Node 12, which cannot parse syntax used by the current Vite CLI.
